### PR TITLE
Add CIRCT as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "circt"]
+	path = circt
+	url = https://github.com/llvm/circt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Set LLVM/MLIR directory paths manually if not installed system-wide
 # These should point to your LLVM build, not source
 # Currently assumes, that circt is located adjacent to this project folder
-set(LLVM_DIR "${CMAKE_SOURCE_DIR}/../circt/llvm/build/lib/cmake/llvm")
-set(MLIR_DIR "${CMAKE_SOURCE_DIR}/../circt/llvm/build/lib/cmake/mlir")
-set(CIRCT_DIR "${CMAKE_SOURCE_DIR}/../circt/build/lib/cmake/circt")
+set(LLVM_DIR "${CMAKE_SOURCE_DIR}/circt/llvm/build/lib/cmake/llvm")
+set(MLIR_DIR "${CMAKE_SOURCE_DIR}/circt/llvm/build/lib/cmake/mlir")
+set(CIRCT_DIR "${CMAKE_SOURCE_DIR}/circt/build/lib/cmake/circt")
 
 # Find LLVM and MLIR packages
 find_package(LLVM REQUIRED CONFIG)


### PR DESCRIPTION
Closes Issue #2.
Working towards Issue #3.

- Added CIRCT as submoule, on commit [f1213ba](https://github.com/llvm/circt/commit/f1213ba8bdbcaba2a4903c5e078fb8c223a2ab39)
- Updated CMakeLists.txt to work with CIRCT as submodule